### PR TITLE
Add permission node and command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,39 @@ Creating: Right click slab with stick
 
 Destroying: Right click existing shop with stick
 
-Perms:
+## Permissions
 
-- slabbo.limit.\<x>
-- slabbo.limit.*
+|                Permission Node | Description                                                                                  |
+| ------------------------------:|:-------------------------------------------------------------------------------------------- |
+|                     slabbo.use | Lets a player use shops                                                                      |
+|                  slabbo.create | Lets a player create shops                                                                   |
+|                   slabbo.admin | Lets a player create admin shops using `/slabbo toggleadmin`                                 |
+|              slabbo.limit.\<x> | Lets a player create a maximum of x shops.                                                   |
+|                slabbo.limit.\* | Lets a player create unlimited shops                                                         |
+|                 slabbo.destroy | Lets a player destroy their shop with `/slabbo destroy`                                      |
+|                  slabbo.modify | Lets a player see help for the Slabbo modification commands                                  |
+|         slabbo.modify.buyprice | Lets a player change the buy price with the modification command                             |
+|        slabbo.modify.sellprice | Lets a player change the sell price with the modification command                            |
+|         slabbo.modify.quantity | Lets a player change the quantity with the modification command                              |
+|                  slabbo.import | Lets a player import shops from another plugin                                               |
+|          slabbo.destroy.others | Lets a player use `/slabbo destroy` to delete other peoples shops                            |
+|  slabbo.modify.buyprice.others | Lets a player use `/slabbo modify buyprice` to modify the buy price of other peoples shops   |
+| slabbo.modify.sellprice.others | Lets a player use `/slabbo modify sellprice` to modify the sell price of other peoples shops |
+|  slabbo.modify.quantity.others | Lets a player use `/slabbo modify quantity` to modify the quantity of other peoples shops    |
+|                    slabbo.info | Lets players use `/slabbo info`                                                              |
+|                  slabbo.reload | Lets players use `/slabbo reload`                                                            |
+|                    slabbo.link | Lets players link chests and shops                                                           |
+
+
+## Commands
+
+- /slabbo
+- /slabbo destroy
+- /slabbo import
+- /slabbo toggleadmin
+- /slabbo modify
+- /slabbo modify buyprice
+- /slabbo modify sellprice
+- /slabbo modify quantity
+- /slabbo reload
+- /slabbo info


### PR DESCRIPTION
These sections directly mirror the spigot page.

### Change detail

- Added permission node documentation and formatted it as a markdown table.
  - Nodes are right-aligned
  - Descriptions are left-aligned
- Added command documentation

### Additional notes

- Characters that have been expected to cause rendering conflicts have been escaped.
- Commands used in node descriptions have been placed inside inline code blocks.