### PR TITLE
Add a command to unlink chests

### DIFF
--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/Slabbo.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/Slabbo.java
@@ -15,10 +15,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import xyz.mackan.Slabbo.abstractions.ISlabboSound;
 import xyz.mackan.Slabbo.abstractions.SlabboAPI;
 import xyz.mackan.Slabbo.abstractions.SlabboItemAPI;
-import xyz.mackan.Slabbo.commands.Conditions;
-import xyz.mackan.Slabbo.commands.SlabboCommand;
-import xyz.mackan.Slabbo.commands.SlabboCommandCompletions;
-import xyz.mackan.Slabbo.commands.SlabboContextResolver;
+import xyz.mackan.Slabbo.commands.*;
 import xyz.mackan.Slabbo.listeners.*;
 import xyz.mackan.Slabbo.pluginsupport.PluginSupport;
 import xyz.mackan.Slabbo.pluginsupport.WorldguardSupport;
@@ -209,6 +206,7 @@ public class Slabbo extends JavaPlugin {
 		Conditions.registerConditions(manager);
 
 		manager.getCommandContexts().registerIssuerOnlyContext(SlabboContextResolver.class, SlabboContextResolver.getContextResolver());
+		manager.getCommandContexts().registerIssuerOnlyContext(LCContextResolver.class, LCContextResolver.getContextResolver());
 
 		manager.registerCommand(new SlabboCommand());
 	}

--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/commands/LCContextResolver.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/commands/LCContextResolver.java
@@ -1,0 +1,54 @@
+package xyz.mackan.Slabbo.commands;
+
+// Linked Chest Context Resolver
+
+import co.aikar.commands.BukkitCommandExecutionContext;
+import co.aikar.commands.ConditionFailedException;
+import co.aikar.commands.contexts.IssuerOnlyContextResolver;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import xyz.mackan.Slabbo.abstractions.ISlabboSound;
+import xyz.mackan.Slabbo.manager.ChestLinkManager;
+import xyz.mackan.Slabbo.manager.LocaleManager;
+import xyz.mackan.Slabbo.types.Shop;
+
+import java.util.Set;
+
+public class LCContextResolver {
+    static ISlabboSound slabboSound = Bukkit.getServicesManager().getRegistration(ISlabboSound.class).getProvider();
+
+    public Block lookingAtBlock;
+
+    LCContextResolver(Block lookingAtBlock) {
+        this.lookingAtBlock = lookingAtBlock;
+    }
+
+    public static Block getLookingAt (Player player) {
+        Block lookingAt = player.getTargetBlock((Set<Material>) null, 6);
+
+
+        if (!ChestLinkManager.isChestLinked(lookingAt)) {
+            return null;
+        }
+
+        return lookingAt;
+    }
+
+    public static IssuerOnlyContextResolver<LCContextResolver, BukkitCommandExecutionContext> getContextResolver () {
+        return (c) -> {
+            Player player = c.getPlayer();
+
+            Block lookingAt = getLookingAt(player);
+
+            if (lookingAt == null) {
+                player.playSound(player.getLocation(), slabboSound.getSoundByKey("BLOCKED"), 1, 1);
+
+                throw new ConditionFailedException(LocaleManager.getString("error-message.general.not-a-linked-chest"));
+            }
+
+            return new LCContextResolver(lookingAt);
+        };
+    }
+}

--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/commands/SlabboCommand.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/commands/SlabboCommand.java
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -920,4 +921,22 @@ public class SlabboCommand extends BaseCommand {
 		}
 	}
 
+	@Subcommand("unlink")
+	@Description("Unlinks the chest you're looking at.")
+	@CommandPermission("slabbo.unlink.self")
+	@Conditions("lookingAtLinkedChest|canExecuteOnLinkedChest:othersPerm=slabbo.unlink.others")
+	public void SlabboUnlinkCommand (Player player, LCContextResolver lcCtx) {
+		Block lookingAtBlock = lcCtx.lookingAtBlock;
+
+		Shop shop = ChestLinkManager.getShopByChestLocation(lookingAtBlock.getLocation());
+
+		ChestLinkManager.removeShopLink(shop);
+		shop.linkedChestLocation = null;
+
+		ShopManager.put(shop.getLocationString(), shop);
+
+		DataUtil.saveShops();
+
+		player.sendMessage(ChatColor.GREEN+LocaleManager.getString("success-message.chestlink.linking-removed"));
+	}
 }

--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/commands/SlabboContextResolver.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/commands/SlabboContextResolver.java
@@ -9,6 +9,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import xyz.mackan.Slabbo.abstractions.ISlabboSound;
+import xyz.mackan.Slabbo.manager.ChestLinkManager;
 import xyz.mackan.Slabbo.manager.LocaleManager;
 import xyz.mackan.Slabbo.manager.ShopManager;
 import xyz.mackan.Slabbo.types.Shop;
@@ -37,6 +38,7 @@ public class SlabboContextResolver {
 		return null;
 	}
 
+
 	public static IssuerOnlyContextResolver<SlabboContextResolver, BukkitCommandExecutionContext> getContextResolver () {
 		return (c) -> {
 			Player player = c.getPlayer();
@@ -50,7 +52,7 @@ public class SlabboContextResolver {
 				throw new ConditionFailedException(LocaleManager.getString("error-message.general.not-a-shop"));
 			}
 
-			return new SlabboContextResolver(getLookingAtShop(player));
+			return new SlabboContextResolver(shop);
 		};
 	}
 }

--- a/modules/Plugin/src/main/resources/acf_lang.yml
+++ b/modules/Plugin/src/main/resources/acf_lang.yml
@@ -22,7 +22,7 @@ acf-core:
   error_generic_logged: "An error occurred. This problem has been logged. Sorry for the inconvenience."
   unknown_command: "Unknown Command, please type <c2>/help</c2>"
   invalid_syntax:Usage: "<c2>{command}</c2> <c3>{syntax}</c3>"
-  error_prefix:Error: "{message}"
+  error_prefix: "Error: {message}"
   error_performing_command: "I'm sorry, but there was an error performing this command."
   info_message: "{message}"
   please_specify_one_of:Error: "Please specify one of (<c2>{valid}</c2>)."

--- a/modules/Plugin/src/main/resources/lang.yml
+++ b/modules/Plugin/src/main/resources/lang.yml
@@ -7,7 +7,9 @@ error-message:
   general:
     limit-hit: You've created all the shops you can! ({limit})
     not-a-shop: That's not a shop.
+    not-a-linked-chest: That's not a linked chest.
     not-shop-owner: That's not your shop.
+    not-linked-chest-owner: That's not your linked chest.
     no-shops-found: No shops were found!
     not-admin-shop: That's not an admin shop.
     no-command-entered: Please enter a command!

--- a/modules/Plugin/src/main/resources/plugin.yml
+++ b/modules/Plugin/src/main/resources/plugin.yml
@@ -30,6 +30,16 @@ permissions:
     children:
       slabbo.destroy.self: true
 
+  slabbo.unlink.self:
+    default: op
+    description: Lets you unlink chests your shops with a command
+
+  slabbo.unlink.others:
+    default: op
+    description: Lets you unlink chests from other peoples shops with a command
+    children:
+      slabbo.unlink.self: true
+
   slabbo.link:
     default: op
     description: Lets you link a shop to a chest
@@ -98,6 +108,7 @@ permissions:
       slabbo.modify.others.sellprice: true
       slabbo.modify.others.quantity: true
       slabbo.modify.others.note: true
+
 
   # ============================================================================== #
 


### PR DESCRIPTION
### Summary

Closes #23

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I've added the `/slabbo unlink` command to unlink the chest you're looking at.
This comes with two new permission nodes; `slabbo.unlink.self` that allows the player to unlink their own chests and `slabbo.unlink.others` that allows the player to unlink others chests.

It also adds two new language keys; `error-message.general.not-a-linked-chest` and `error-message.general.not-linked-chest-owner`

