### PR TITLE
Add support for formatting currency with vault

### DIFF
--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/GUI/items/GUIItems.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/GUI/items/GUIItems.java
@@ -33,9 +33,7 @@ public class GUIItems {
 		String clickToSet = LocaleManager.getString("general.general.click-to-set");
 		String explainer = LocaleManager.getString("general.general.not-for-sale-explain");
 
-		boolean allowCents = Slabbo.getInstance().getConfig().getBoolean("allowCents", false);
-
-		String currencyString = allowCents ? LocaleManager.getCurrencyString(buyPrice) : LocaleManager.getCurrencyString((int) buyPrice);
+		String currencyString = LocaleManager.getCurrencyString(buyPrice);
 
 		meta.setLore(Arrays.asList("§r"+currencyString, clickToSet, "§r"+explainer));
 
@@ -54,8 +52,7 @@ public class GUIItems {
 		String clickToSet = LocaleManager.getString("general.general.click-to-set");
 		String explainer = LocaleManager.getString("general.general.not-buying-explain");
 
-		boolean allowCents = Slabbo.getInstance().getConfig().getBoolean("allowCents", false);
-		String currencyString = allowCents ? LocaleManager.getCurrencyString(sellPrice) : LocaleManager.getCurrencyString((int) sellPrice);
+		String currencyString = LocaleManager.getCurrencyString(sellPrice);
 
 		meta.setLore(Arrays.asList("§r"+currencyString, clickToSet, "§r"+explainer));
 
@@ -119,9 +116,7 @@ public class GUIItems {
 		replacementMap.put("item", "'"+itemName+"'");
 		replacementMap.put("quantity", quantity);
 
-		boolean allowCents = Slabbo.getInstance().getConfig().getBoolean("allowCents", false);
-
-		String currencyString = allowCents ? LocaleManager.getCurrencyString(price) : LocaleManager.getCurrencyString((int) price);
+		String currencyString = LocaleManager.getCurrencyString(price);
 
 		replacementMap.put("price", currencyString);
 
@@ -165,9 +160,7 @@ public class GUIItems {
 		replacementMap.put("item", "'"+itemName+"'");
 		replacementMap.put("quantity", quantity);
 
-		boolean allowCents = Slabbo.getInstance().getConfig().getBoolean("allowCents", false);
-
-		String currencyString = allowCents ? LocaleManager.getCurrencyString(price) : LocaleManager.getCurrencyString((int) price);
+		String currencyString = LocaleManager.getCurrencyString(price);
 
 		replacementMap.put("price", currencyString);
 
@@ -215,7 +208,9 @@ public class GUIItems {
 
 		HashMap<String, Object> replacementMap = new HashMap<String, Object>();
 
-		replacementMap.put("funds", "§a"+LocaleManager.getCurrencyString(formatter.format(funds)));
+		//replacementMap.put("funds", "§a"+LocaleManager.getCurrencyString(formatter.format(funds)));
+		replacementMap.put("funds", "§a"+LocaleManager.getCurrencyString(funds));
+
 
 		meta.setLore(Arrays.asList(LocaleManager.replaceKey("general.general.funds-message", replacementMap)));
 
@@ -232,10 +227,6 @@ public class GUIItems {
 
 		double buyPerItem = 0;
 		double sellPerItem = 0;
-		boolean allowCents = Slabbo.getInstance().getConfig().getBoolean("allowCents", false);
-
-
-		NumberFormat formatter = new DecimalFormat("#0.00");
 
 		// TODO: Actually check if these are zero
 		try { buyPerItem = shop.quantity / shop.buyPrice; } catch (Exception e) {}
@@ -251,15 +242,13 @@ public class GUIItems {
 		replacementMap.put("owner", ownerName);
 		replacementMap.put("item", shop.item.getType());
 		replacementMap.put("quantity", shop.quantity);
-		if (allowCents) {
-			replacementMap.put("buyPrice", shop.buyPrice);
-			replacementMap.put("sellPrice", shop.sellPrice);
-		} else {
-			replacementMap.put("buyPrice", (int) shop.buyPrice);
-			replacementMap.put("sellPrice", (int) shop.sellPrice);
-		}
-		replacementMap.put("buyPerItem", LocaleManager.getCurrencyString(formatter.format(buyPerItem)));
-		replacementMap.put("sellPerItem", LocaleManager.getCurrencyString(formatter.format(sellPerItem)));
+
+		replacementMap.put("buyPrice", LocaleManager.getCurrencyString(shop.buyPrice));
+		replacementMap.put("sellPrice", LocaleManager.getCurrencyString(shop.sellPrice));
+
+
+		replacementMap.put("buyPerItem", LocaleManager.getCurrencyString(buyPerItem));
+		replacementMap.put("sellPerItem", LocaleManager.getCurrencyString(sellPerItem));
 
 		if (shop.shopLimit != null && shop.shopLimit.enabled) {
 			replacementMap.put("restockTime", shop.shopLimit.restockTime);

--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/manager/LocaleManager.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/manager/LocaleManager.java
@@ -1,5 +1,6 @@
 package xyz.mackan.Slabbo.manager;
 
+import jdk.vm.ci.meta.Local;
 import org.bukkit.configuration.MemorySection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -11,6 +12,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -18,6 +20,9 @@ import java.util.regex.Pattern;
 
 public class LocaleManager {
 	private static HashMap<String, String> translationMap = new HashMap<String, String>();
+	private static boolean allowCents = Slabbo.getInstance().getConfig().getBoolean("allowCents", false);
+	private static boolean formatCurrencyWithVault = Slabbo.getInstance().getConfig().getString("currencyFormat", "vault").equalsIgnoreCase("vault");
+
 
 
 	/**
@@ -120,7 +125,27 @@ public class LocaleManager {
 	 * @param amount The amount of currency
 	 * @return String
 	 */
-	public static String getCurrencyString (Object amount) {
-		return replaceSingleKey("general.currency-format", "amount", amount);
+	public static String getCurrencyString (String amount) {
+		return LocaleManager.getCurrencyString(Double.parseDouble(amount));
+	}
+
+	/**
+	 * Gets the currency string with the amount
+	 * @param amount The amount of currency
+	 * @return String
+	 */
+	public static String getCurrencyString (int amount) {
+		return LocaleManager.getCurrencyString((double) amount);
+	}
+
+	/**
+	 * Gets the currency string with the amount
+	 * @param amount The amount of currency
+	 * @return String
+	 */
+	public static String getCurrencyString (double amount) {
+		if (formatCurrencyWithVault) return Slabbo.getEconomy().format(amount);
+
+		return allowCents ? replaceSingleKey("general.currency-format", "amount", amount) : replaceSingleKey("general.currency-format", "amount", (int) amount);
 	}
 }

--- a/modules/Plugin/src/main/resources/config.yml
+++ b/modules/Plugin/src/main/resources/config.yml
@@ -48,6 +48,11 @@ disableShops: false
 # If the shops should allow for setting prices using decimal points (i.e. 1.05)
 allowCents: false
 
+# How to format the currency strings.
+# If set to "Slabbo", the "general.currency-format" language key will be used.
+# If set to "Vault", the formatting from vault (and your economy plugin) will be used.
+currencyFormat: Vault
+
 ########################
 #     Chest links      #
 ########################


### PR DESCRIPTION
### Summary

Closes #18 

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I've added the `currencyFormat` configuration key, which takes `vault` or `slabbo` as values in order to set which currency formatter to use.

In relation to this, I've refactored the code in a way where all calls for formatting currency now uses `LocaleManager#getCurrencyString`, as it now handles all that fun stuff.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Finally, if your pull request affects documentation or any non-code
changes, please document those too.

Thanks for contributing to Slabbo! -->