### PR TITLE
Fix oversized withdrawal always being active

### DIFF
--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/GUI/ShopAdminGUI.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/GUI/ShopAdminGUI.java
@@ -26,6 +26,7 @@ import xyz.mackan.Slabbo.types.Shop;
 import xyz.mackan.Slabbo.manager.ChestLinkManager;
 import xyz.mackan.Slabbo.types.ShopAction;
 import xyz.mackan.Slabbo.utils.DataUtil;
+import xyz.mackan.Slabbo.utils.InventoryUtil;
 import xyz.mackan.Slabbo.utils.NameUtil;
 import xyz.mackan.Slabbo.manager.ShopManager;
 
@@ -198,6 +199,8 @@ public class ShopAdminGUI implements Listener {
 
 	public void handleWithdraw (HumanEntity humanEntity, ClickType clickType) {
 		boolean isBulk = clickType.equals(ClickType.SHIFT_LEFT);
+		boolean withdrawOversized = Slabbo.getInstance().getConfig().getBoolean("withdrawOversized", false);
+
 
 		Player player = (Player) humanEntity;
 
@@ -227,15 +230,8 @@ public class ShopAdminGUI implements Listener {
 
 		ItemStack shopItemClone = shop.item.clone();
 
-		shopItemClone.setAmount(tempTransferRate);
+		int leftoverCount = InventoryUtil.addItemsToPlayerInventory(pInv, shopItemClone, tempTransferRate, withdrawOversized);
 
-		HashMap<Integer, ItemStack> leftovers = pInv.addItem(shopItemClone);
-
-		int leftoverCount = leftovers
-				.values()
-				.stream()
-				.map(stack -> stack.getAmount())
-				.reduce(0, (total, el) -> total + el);
 
 		if (!shop.admin) {
 			shop.stock -= (tempTransferRate - leftoverCount);

--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/GUI/ShopUserGUI.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/GUI/ShopUserGUI.java
@@ -17,6 +17,7 @@ import xyz.mackan.Slabbo.abstractions.SlabboAPI;
 import xyz.mackan.Slabbo.manager.LocaleManager;
 import xyz.mackan.Slabbo.types.Shop;
 import xyz.mackan.Slabbo.utils.DataUtil;
+import xyz.mackan.Slabbo.utils.InventoryUtil;
 import xyz.mackan.Slabbo.utils.NameUtil;
 
 import java.util.ArrayList;
@@ -125,47 +126,9 @@ public class ShopUserGUI implements Listener {
 
 		PlayerInventory pInv = humanEntity.getInventory();
 
-		List<ItemStack> stacksToAdd = new ArrayList<ItemStack>();
-
 		ItemStack shopItemClone = shop.item.clone();
 
-		if (sellOversized) {
-			shopItemClone.setAmount(itemCount);
-			stacksToAdd.add(shopItemClone);
-		} else {
-			int maxStackSize = slabboAPI.getMaxStack(shopItemClone);
-
-			int stacks = (int)Math.floor(itemCount / maxStackSize);
-			int lastStack = itemCount % maxStackSize;
-
-			//int totalStacks = (totalItems / maxStackSize + (totalItems % maxStackSize));
-
-
-			for (int i = 0;i<stacks;i++) {
-				int size = maxStackSize;
-
-				ItemStack clonedStack = shop.item.clone();
-				clonedStack.setAmount(size);
-				stacksToAdd.add(clonedStack);
-			}
-
-			if (lastStack > 0) {
-				ItemStack clonedStack = shop.item.clone();
-				clonedStack.setAmount(lastStack);
-				stacksToAdd.add(clonedStack);
-			}
-		}
-
-		ItemStack[] stackArray = stacksToAdd.toArray(new ItemStack[stacksToAdd.size()]);
-		HashMap<Integer, ItemStack> leftovers = pInv.addItem(stackArray);
-
-		// TODO: Make this do a dry run to see if the player can acutally get all the items
-		int leftoverCount = leftovers
-				.values()
-				.stream()
-				.map(stack -> stack.getAmount())
-				.reduce(0, (total, el) -> total + el);
-
+		int leftoverCount = InventoryUtil.addItemsToPlayerInventory(pInv, shopItemClone, itemCount, sellOversized);
 
 		int totalBought = itemCount - leftoverCount;
 

--- a/modules/Plugin/src/main/java/xyz/mackan/Slabbo/utils/InventoryUtil.java
+++ b/modules/Plugin/src/main/java/xyz/mackan/Slabbo/utils/InventoryUtil.java
@@ -1,0 +1,56 @@
+package xyz.mackan.Slabbo.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import xyz.mackan.Slabbo.Slabbo;
+import xyz.mackan.Slabbo.abstractions.SlabboAPI;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class InventoryUtil {
+    static SlabboAPI slabboAPI = Bukkit.getServicesManager().getRegistration(SlabboAPI.class).getProvider();
+
+    public static int addItemsToPlayerInventory(PlayerInventory playerInventory, ItemStack item, int itemCount, boolean oversized) {
+        List<ItemStack> stacksToAdd = new ArrayList<ItemStack>();
+
+        if (oversized) {
+            item.setAmount(itemCount);
+            stacksToAdd.add(item);
+        } else {
+            int maxStackSize = slabboAPI.getMaxStack(item);
+
+            int stacks = (int)Math.floor(itemCount / maxStackSize);
+            int lastStack = itemCount % maxStackSize;
+
+            for (int i = 0;i<stacks;i++) {
+                int size = maxStackSize;
+
+                ItemStack clonedStack = item.clone();
+                clonedStack.setAmount(size);
+                stacksToAdd.add(clonedStack);
+            }
+
+            if (lastStack > 0) {
+                ItemStack clonedStack = item.clone();
+                clonedStack.setAmount(lastStack);
+                stacksToAdd.add(clonedStack);
+            }
+        }
+
+        ItemStack[] stackArray = stacksToAdd.toArray(new ItemStack[stacksToAdd.size()]);
+        HashMap<Integer, ItemStack> leftovers = playerInventory.addItem(stackArray);
+
+        // TODO: Make this do a dry run to see if the player can acutally get all the items
+        int leftoverCount = leftovers
+                .values()
+                .stream()
+                .map(stack -> stack.getAmount())
+                .reduce(0, (total, el) -> total + el);
+
+
+        return leftoverCount;
+    }
+}

--- a/modules/Plugin/src/main/resources/config.yml
+++ b/modules/Plugin/src/main/resources/config.yml
@@ -26,6 +26,11 @@ barriershops: true
 # an oversized stack can have 64 items.
 sellOversized: false
 
+# If shops can withdraw oversized stacks
+# I.e, a regular stack of pickaxes can only have one item,
+# an oversized stack can have 64 items.
+withdrawOversized: false
+
 # The maximum amount of items a shop can keep in stock.
 # Set to -1 for unlimited
 maxStockSize: -1


### PR DESCRIPTION
### Summary

Fixes #57 

- Adds the config option `withdrawOversized`, which is `false` by default. Option behaves like `sellOversized`, but for withdrawal of items.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Finally, if your pull request affects documentation or any non-code
changes, please document those too.

Thanks for contributing to Slabbo! -->